### PR TITLE
feat(react): extend native props

### DIFF
--- a/packages/quark-react/src/dialog/index.ts
+++ b/packages/quark-react/src/dialog/index.ts
@@ -1,24 +1,11 @@
 import { FC } from 'react';
+import type DialogFn from 'quarkd/lib/dialog'
 import reactify from "@quarkd/reactify";
 import 'quarkd/lib/dialog';
-import { componentBaseInterface } from '../type';
+import { ReactifyProps } from '../type';
 
-interface DialogProps extends componentBaseInterface{
-    title?: string
-    content?: string
-    oktext?: string;
-    canceltext?: string
-    open: boolean
-    zindex?: number
-    type?: 'modal' | 'confirm'
-    btnVertical?: boolean;
-    nofooter?: boolean
-    hideclose?: boolean
-    autoclose?: boolean
-    onConfirm: () => void
-    onCancel: () => void
-    onClose: () => void
-}
+
+type DialogProps = ReactifyProps<Parameters<typeof DialogFn>[0]>
 type DialogType =  FC<DialogProps>;
 
 const Dialog = reactify('quark-dialog') as DialogType;

--- a/packages/quark-react/src/type/index.ts
+++ b/packages/quark-react/src/type/index.ts
@@ -1,8 +1,22 @@
-export interface componentBaseInterface {
-    className?: string
-    key?: string 
-    children?: any
-    slot?: string
+type Merge<F, S> = Omit<F, keyof S> & S extends infer R
+  ? {[K in keyof R]: R[K]}
+  : never
+
+export type ReactifyProps<T extends Record<string, any>> = Merge<
+    componentBaseInterface,
+    {
+        [K in keyof T as (
+            T[K] extends Function 
+            ? (K extends string ? `on${Capitalize<K>}`: K)
+            : K
+            )]: T[K]
+    }>
+
+export interface componentBaseInterface extends 
+    React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>, 
+        HTMLElement
+        >
+     {
     name?: string
-    onClick?: () => void
 }


### PR DESCRIPTION
I've noticed that all the custom web-components are extending `HTMLElement`, so we should treat them as well as `HTMLElement` when passing props(native events, attributes and more...), NOT just limited in`componentBaseInterface`.

So this PR did two things:
- Make `componentBaseInterface` extend `HTMLElement` props.
- An useful typescript utility type `ReactifyProps` that transforms web-component props to the corresponding react props. (so we don't need to `write/change/add` in two places)

And, with an example usage in the `Dialog` component.