### PR TITLE
fix: fix some bug of doc site

### DIFF
--- a/example/src/sites/doc/views/Index.vue
+++ b/example/src/sites/doc/views/Index.vue
@@ -113,6 +113,7 @@ export default defineComponent({
 
     // react / vue 文档切换
     const handleTabs = (curKey: string) => {
+      if (data.curKey == curKey) return;
       data.curKey = curKey;
       localStorage.setItem('docMd', curKey);
       watchDocMd(curKey);


### PR DESCRIPTION
There is a bug in the tab button of the current example that used to switch vue/react, this bug will cause the route splicing error and then jump to the first component.