### PR TITLE
feat(Icon): add default icon size 20px

### DIFF
--- a/packages/quark-icons/utils/index.ts
+++ b/packages/quark-icons/utils/index.ts
@@ -1,11 +1,11 @@
-
+// 获取fontSize，默认值20px，避免用户未设置size属性而元素不可见
 export function getFontSize(size: string|null){
     let fontSize = '';
     if (size && /\d(px|rem|em|vh|vw)$/.test(size)
     ) {
         fontSize = size;
     } else {
-        fontSize = `${size}px`;
+        fontSize = size ? `${size}px` : '20px';
     }
     return fontSize;
 }

--- a/packages/quark/src/icon/doc-react.en-US.md
+++ b/packages/quark/src/icon/doc-react.en-US.md
@@ -43,4 +43,4 @@ Use `color` prop to set icon color.
 | Attribute         | Description                             | Type             | Default           |
 |--------------|----------------------------------|------------------|------------------|
 | color        | Icon color                           | `string `          | -                |
-| size         | Icon size，such as `20px` `2em` `2rem`    | `string or number` | -                |
+| size         | Icon size，such as `20` `20px` `2em` `2rem` `2vh` `2vw`| `string or number` | `20px`     |

--- a/packages/quark/src/icon/doc-react.zh-CN.md
+++ b/packages/quark/src/icon/doc-react.zh-CN.md
@@ -42,4 +42,4 @@ import '@quarkd/icons/lib/user';
 | 参数         | 说明                             | 类型             | 默认值           |
 |--------------|----------------------------------|------------------|------------------|
 | color        | 图标颜色                           | `string`           | -                |
-| size         | 图标大小，如 `20px` `2em` `2rem`    | `string or number` | -                |
+| size         | 图标大小，如 `20` `20px` `2em` `2rem` `2vh` `2vw`| `string or number` | `20px`     |

--- a/packages/quark/src/icon/doc.en-US.md
+++ b/packages/quark/src/icon/doc.en-US.md
@@ -43,4 +43,4 @@ Use `color` prop to set icon color.
 | Attribute         | Description                             | Type             | Default           |
 |--------------|----------------------------------|------------------|------------------|
 | color        | Icon color                           | `string `          | -                |
-| size         | Icon size，such as `20px` `2em` `2rem`    | `string or number` | -                |
+| size         | Icon size，such as `20` `20px` `2em` `2rem` `2vh` `2vw`| `string or number` | `20px`     |

--- a/packages/quark/src/icon/doc.zh-CN.md
+++ b/packages/quark/src/icon/doc.zh-CN.md
@@ -42,4 +42,4 @@ import '@quarkd/icons/lib/user';
 | 参数         | 说明                             | 类型             | 默认值           |
 |--------------|----------------------------------|------------------|------------------|
 | color        | 图标颜色                           | `string`           | -                |
-| size         | 图标大小，如 `20px` `2em` `2rem`    | `string or number` | -                |
+| size         | 图标大小，如 `20` `20px` `2em` `2rem` `2vh` `2vw`| `string or number` | `20px`     |


### PR DESCRIPTION
增加Icon的默认size为20px，避免在用户未添加属性的时候看不到icon

并补充了文档相关默认值内容