### PR TITLE
fix(cascadepicker): fix only one colum

### DIFF
--- a/packages/quark/src/cascadepicker/index.tsx
+++ b/packages/quark/src/cascadepicker/index.tsx
@@ -81,9 +81,6 @@ class QuarkCascadePicker extends QuarkElement {
     const firstColumn = this.columns[0];
     this.depth = this.getDepths(firstColumn, 1);
     this.selectedIndexPair = new Array(this.depth).fill(0);
-    if (this.depth <= 1) {
-      return;
-    }
 
     this.loadInitPickerData();
 


### PR DESCRIPTION

when data only have one colum

- demo

```js
const DATA = [
        {
          text: `${translate("options.zhejiang")}`,
        },
        {
          text: `${translate("options.fujian")}`,
        },
      ];
preview.setColumns(DATA);
```