### PR TITLE
fix(popupextra): 部分安卓机型 mpaas 容器上浮层存在灰点修复

### DIFF
--- a/packages/quark/src/popupextra/style.css
+++ b/packages/quark/src/popupextra/style.css
@@ -85,7 +85,7 @@
   border-top-right-radius: var(--popup-extra-border-radius, quark-radiusBg);
 }
 :host .quark-popup-extra-body {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 :host([open]) .quark-popup-extra {


### PR DESCRIPTION
在部分安卓机型上，命中 mpaas 容器，浮层(popupextra)上面会有灰点，如下：