### PR TITLE
fix: test(tab/step) & docs example(checkbox/radio)

### DIFF
--- a/packages/quark/src/checkbox/doc-react.en-US.md
+++ b/packages/quark/src/checkbox/doc-react.en-US.md
@@ -41,8 +41,8 @@ export default () => {
 Checkbox shape supports `round` and `square`, the default is `round`.
 
 ```html
-<Checkbox checked="{true}">round(default)</Checkbox>
-<Checkbox checked="{true}" shape="square">square</Checkbox>
+<Checkbox checked={true}>round(default)</Checkbox>
+<Checkbox checked={true} shape="square">square</Checkbox>
 ```
 
 ### Size
@@ -50,10 +50,10 @@ Checkbox shape supports `round` and `square`, the default is `round`.
 Checkbox size supports `normal` and `big`, the default is `normal`.
 
 ```html
-<Checkbox checked="{true}" shape="round" size="big"
+<Checkbox checked={true} shape="round" size="big"
   >default shape - big</Checkbox
 >
-<Checkbox checked="{true}" shape="square" size="big">square - big</Checkbox>
+<Checkbox checked={true} shape="square" size="big">square - big</Checkbox>
 ```
 
 ### Disabled
@@ -61,8 +61,8 @@ Checkbox size supports `normal` and `big`, the default is `normal`.
 To disable Checkbox, add `disabled` prop on the Checkbox.
 
 ```html
-<Checkbox checked="{true}" disabled>checked - disabled</Checkbox>
-<Checkbox checked="{true}" disabled>unchecked - disabled</Checkbox>
+<Checkbox checked={true} disabled>checked - disabled</Checkbox>
+<Checkbox checked={true} disabled>unchecked - disabled</Checkbox>
 ```
 
 ### Checkbox Group
@@ -97,7 +97,7 @@ export default () => {
 Custom checked color
 
 ```html
-<Checkbox checked="{true}">Checkbox-Custom checked color</Checkbox>
+<Checkbox checked={true}>Checkbox-Custom checked color</Checkbox>
 
 <!-- CSS -->
 Checkbox { --radio-background: linear-gradient(225deg, #ff918d 0%, #f54640

--- a/packages/quark/src/checkbox/doc-react.zh-CN.md
+++ b/packages/quark/src/checkbox/doc-react.zh-CN.md
@@ -40,8 +40,8 @@ export default () => {
 复选框支持`round`、`square`两种形状，默认为 `round`。
 
 ```html
-<Checkbox checked="{true}">圆形(默认)</Checkbox>
-<Checkbox checked="{true}" shape="square">方形</Checkbox>
+<Checkbox checked={true}>圆形(默认)</Checkbox>
+<Checkbox checked={true} shape="square">方形</Checkbox>
 ```
 
 ### 复选框大小
@@ -49,8 +49,8 @@ export default () => {
 复选框大小支持 `normal`、`big` 两种，默认为 `normal`。
 
 ```html
-<Checkbox checked="{true}" shape="round" size="big">默认形状-大</Checkbox>
-<Checkbox checked="{true}" shape="square" size="big">方形-大</Checkbox>
+<Checkbox checked={true} shape="round" size="big">默认形状-大</Checkbox>
+<Checkbox checked={true} shape="square" size="big">方形-大</Checkbox>
 ```
 
 ### 复选框禁用状态
@@ -58,8 +58,8 @@ export default () => {
 复选框支持禁用
 
 ```html
-<Checkbox checked="{true}" disabled>已选-禁用</Checkbox>
-<Checkbox checked="{true}" disabled>未选-禁用</Checkbox>
+<Checkbox checked={true} disabled>已选-禁用</Checkbox>
+<Checkbox checked={true} disabled>未选-禁用</Checkbox>
 ```
 
 ### 复选框群组
@@ -94,7 +94,7 @@ export default () => {
 复选框选中颜色自定义
 
 ```html
-<Checkbox checked="{true}">复选框-选中颜色自定义</Checkbox>
+<Checkbox checked={true}>复选框-选中颜色自定义</Checkbox>
 
 <!-- CSS -->
 Checkbox { --radio-background: linear-gradient(225deg, #ff918d 0%, #f54640

--- a/packages/quark/src/radio/doc-react.en-US.md
+++ b/packages/quark/src/radio/doc-react.en-US.md
@@ -78,12 +78,12 @@ Radio size supports `normal` and `big`, the default is `normal`.
 To disable radio, add `disabled` prop on the Radio.
 
 ```html
-<Radio checked="{true}" disabled>checked - disabled</Radio>
-<Radio checked="{false}" disabled>unchecked - disabled</Radio>
-<Radio checked="{true}" shape="square" disabled
+<Radio checked={true} disabled>checked - disabled</Radio>
+<Radio checked={false} disabled>unchecked - disabled</Radio>
+<Radio checked={true} shape="square" disabled
   >square - checked - disabled</Radio
 >
-<Radio checked="{false}" shape="square" disabled
+<Radio checked={false} shape="square" disabled
   >square - unchecked - disabled</Radio
 >
 ```

--- a/packages/quark/src/radio/doc-react.zh-CN.md
+++ b/packages/quark/src/radio/doc-react.zh-CN.md
@@ -78,10 +78,10 @@ export default () => {
 单选框支持禁用
 
 ```html
-<Radio checked="{true}" disabled>已选-禁用</Radio>
-<Radio checked="{false}" disabled>未选-禁用</Radio>
-<Radio checked="{true}" shape="square" disabled>方形-已选-禁用</Radio>
-<Radio checked="{false}" shape="square" disabled>方形-未选-禁用</Radio>
+<Radio checked={true} disabled>已选-禁用</Radio>
+<Radio checked={false} disabled>未选-禁用</Radio>
+<Radio checked={true} shape="square" disabled>方形-已选-禁用</Radio>
+<Radio checked={false} shape="square" disabled>方形-未选-禁用</Radio>
 ```
 
 ### 单选框风格

--- a/packages/quark/src/steps/index.test.js
+++ b/packages/quark/src/steps/index.test.js
@@ -7,25 +7,25 @@ const data = {
 let el;
 
 describe("<quark-step>", async () => {
-  // it('element exist', async () => {
-  //     el = await fixture(
-  //         `<quark-steps>
-  //             <quark-step status="done" title="步骤一">1</quark-step>
-  //             <quark-step status="doing" title="步骤二">2</quark-step>
-  //             <quark-step status="todo" title="步骤三">3</quark-step>
-  //         </quark-steps>`);
-  //     const step = el.shadowRoot.querySelector('.quark-steps-horizontal');
-  //     expect(step).to.exist;
-  // });
-  // it('direction attribute', async () => {
-  //     el = await fixture(
-  //         `<quark-steps direction=${data.direction}>
-  //             <quark-step status="done" title="步骤一">1</quark-step>
-  //             <quark-step status="doing" title="步骤二">2</quark-step>
-  //             <quark-step status="todo" title="步骤三">3</quark-step>
-  //         </quark-steps>`);
-  //     const step = el.shadowRoot.querySelector('.quark-steps');
-  //     expect(step).to.exist;
-  //     expect(el.direction).to.equal(data.direction);
-  // });
+  it('element exist', async () => {
+      el = await fixture(
+          `<quark-steps>
+              <quark-step status="done" title="步骤一">1</quark-step>
+              <quark-step status="doing" title="步骤二">2</quark-step>
+              <quark-step status="todo" title="步骤三">3</quark-step>
+          </quark-steps>`);
+      const step = el.shadowRoot.querySelector('.quark-steps-horizontal');
+      expect(step).to.exist;
+  });
+  it('direction attribute', async () => {
+      el = await fixture(
+          `<quark-steps direction=${data.direction}>
+              <quark-step status="done" title="步骤一">1</quark-step>
+              <quark-step status="doing" title="步骤二">2</quark-step>
+              <quark-step status="todo" title="步骤三">3</quark-step>
+          </quark-steps>`);
+      const step = el.shadowRoot.querySelector('.quark-vertical');
+      expect(el.direction).to.equal(data.direction);
+      expect(step).to.exist;
+  });
 });

--- a/packages/quark/src/tab/index.test.js
+++ b/packages/quark/src/tab/index.test.js
@@ -6,41 +6,41 @@ const data = {
 };
 let el;
 describe("quark-tabs base attribute", async () => {
-  // before(async () => {
-  //   el = await fixture(
-  //   `<quark-tabs
-  //     activekey=${data.activekey}
-  //   >
-  //     <quark-tab-content label="tab1">
-  //       tab1 content
-  //     </quark-tab-content>
-  //     <quark-tab-content label="tab2">
-  //       tab2 content
-  //     </quark-tab-content>
-  //   </quark-tabs>`);
-  // });
-  // it('tabs exist', async () => {
-  //   const tabs = el.shadowRoot.querySelector('.tabs');
-  //   expect(tabs).to.exist;
-  // });
-  // it('activekey attribute', () => {
-  //   expect(el.activekey).to.equal(data.activekey);
-  // });
-  // it('change Event', async() => {
-  //   const node = await fixture(
-  //     `<quark-tabs activekey=${data.activekey}>
-  //       <quark-tab-content label="tab1">
-  //         tab1 content
-  //       </quark-tab-content>
-  //       <quark-tab-content label="tab2">
-  //         tab2 content
-  //       </quark-tab-content>
-  //     </quark-tabs>`
-  //   );
-  //   const eventspy = sinon.spy()
-  //   node.addEventListener('change', eventspy);
-  //   const nav = node.shadowRoot.querySelector('#nav');
-  //   nav.dispatchEvent(new Event('click'));
-  //   expect(eventspy.called).to.equal(true);
-  // });
+  before(async () => {
+    el = await fixture(
+    `<quark-tabs
+      activekey=${data.activekey}
+    >
+      <quark-tab-content label="tab1">
+        tab1 content
+      </quark-tab-content>
+      <quark-tab-content label="tab2">
+        tab2 content
+      </quark-tab-content>
+    </quark-tabs>`);
+  });
+  it('tabs exist', async () => {
+    const tabs = el.shadowRoot.querySelector('.quark-tab-nav');
+    expect(tabs).to.exist;
+  });
+  it('activekey attribute', () => {
+    expect(el.activekey).to.equal(data.activekey);
+  });
+  it('change Event', async() => {
+    const node = await fixture(
+      `<quark-tabs activekey=${data.activekey}>
+        <quark-tab-content label="tab1">
+          tab1 content
+        </quark-tab-content>
+        <quark-tab-content label="tab22">
+          tab2 content
+        </quark-tab-content>
+      </quark-tabs>`
+    );
+    const eventspy = sinon.spy() 
+    const nav = node.shadowRoot.querySelector('.quark-tab-nav');
+    nav.addEventListener('click', eventspy);
+    nav.dispatchEvent(new Event('click'));
+    expect(eventspy.called).to.equal(true);
+  });
 });


### PR DESCRIPTION
1. react 组件中 boolean 这种写法有错误
2. tab / steps 中的 test被注释了看了一下是因为有一点错误
比如 
```
steps [direction=](direction: "vertical")
this.direction === "vertical" ? "quark-vertical"
所以 const step = el.shadowRoot.querySelector('.quark-steps'); 始终没有exist

```
已经将注释掉的代码修复并跑了一遍yarn test了，都是通过的哦
