### PR TITLE
fix: test(dialog/image/popupextra)

### DIFF
--- a/packages/quark/src/dialog/index.test.js
+++ b/packages/quark/src/dialog/index.test.js
@@ -5,6 +5,7 @@ const data = {
   title: "我是标题",
   oktext: "确定",
   canceltext: "取消",
+  content: "弹窗的内容"
 };
 let el;
 describe("quark-dialog base attribute", async () => {
@@ -14,6 +15,7 @@ describe("quark-dialog base attribute", async () => {
         title=${data["title"]}
         oktext=${data["oktext"]}
         canceltext=${data["canceltext"]}
+        content=${data["content"]}
         
     >
     </quark-dialog>`
@@ -28,10 +30,9 @@ describe("quark-dialog base attribute", async () => {
     expect(el.title).to.equal(data["title"]);
   });
 
-  // it('content attribute', () => {
-  //   console.log(el, 'el')
-  //   expect(el.content).to.equal(data['content']);
-  // });
+  it('content attribute', () => {
+    expect(el.content).to.equal(data['content']);
+  });
 
   it("oktext attribute", () => {
     expect(el["oktext"]).to.equal(data["oktext"]);
@@ -78,7 +79,7 @@ describe("quark-dialog Dom attribute", async () => {
   //     >
   //       </quark-dialog>`
   //   );
-  //   const okBtn = node.shadowRoot.querySelector("");
+  //   const okBtn = node.shadowRoot.querySelector(".quark-dialog-confirm-btn");
   //   const eventspy = sinon.spy();
   //   node.addEventListener("confirm", eventspy);
   //   okBtn.dispatchEvent(new Event("click"));

--- a/packages/quark/src/dialog/index.tsx
+++ b/packages/quark/src/dialog/index.tsx
@@ -56,10 +56,10 @@ class QuarkDialog extends QuarkElement {
   content: string | HTMLElement = "";
 
   @property()
-  oktext: string = Locale.current.confirm;
+  oktext = Locale.current.confirm;
 
   @property()
-  canceltext: string = Locale.current.cancel;
+  canceltext = Locale.current.cancel;
 
   @property()
   type = "modal";
@@ -297,7 +297,11 @@ class QuarkDialog extends QuarkElement {
                     >
                       {this.canceltext}
                     </quark-button>
-                    <quark-button type="primary" onClick={this.okClick}>
+                    <quark-button
+                      class="quark-dialog-confirm-btn"
+                      type="primary"
+                      onClick={this.okClick}
+                    >
                       {this.oktext}
                     </quark-button>
                   </div>

--- a/packages/quark/src/image/index.test.js
+++ b/packages/quark/src/image/index.test.js
@@ -15,31 +15,28 @@ const data = {
 let el;
 
 describe("<quark-image>", async () => {
-  // it('element exist', async () => {
-  //   el = await fixture(
-  //     `<quark-image
-  //     ></quark-image>`
-  //   );
-  //   const img = el.shadowRoot.querySelector('img');
-  //   expect(img).to.exist;
-  // });
-  // it('element attribute exist', async () => {
-  //   el = await fixture(
-  //     `<quark-image
-  //     src=${data.src}
-  //     width=${data.width}
-  //     height=${data.height}
-  //     fit=${data.fit}
-  //     lazy=${data.lazy}
-  //     round=${data.round}
-  //     ></quark-image>`
-  //   );
-  //   const img = el.shadowRoot.querySelector('img');
-  //   expect(el.lazy).to.equal(data.lazy);
-  //   expect(el.round).to.equal(data.round);
-  //   expect(img.src).to.equal(data.src);
-  //   expect(img.width).to.exist;
-  //   expect(img.height).to.exist;
-  //   // expect(img['object-fit']).to.equal(data.fit);
-  // });
+  before(async () => {
+    el = await fixture(
+      `<quark-image
+      src=${data.src}
+      width=${data.width}
+      height=${data.height}
+      fit=${data.fit}
+      lazy=${data.lazy}
+      round=${data.round}
+      ></quark-image>`
+    );
+  });
+  it('element exist', async () => {
+    const img = el.shadowRoot.querySelector('img');
+    expect(img).to.exist;
+  });
+  it('element attribute exist', async () => {
+    expect(el.lazy).to.equal(data.lazy);
+    expect(el.round).to.equal(data.round);
+    expect(el.src).to.equal(data.src);
+    expect(el.width).to.equal(data.width);
+    expect(el.height).to.equal(data.height);
+    expect(el.fit).to.equal(data.fit)
+  });
 });

--- a/packages/quark/src/image/index.tsx
+++ b/packages/quark/src/image/index.tsx
@@ -94,7 +94,7 @@ class QuarkImage extends QuarkElement {
   }
 
   render() {
-    const alt = this.alt ? {alt: this.alt} : {};
+    const alt = this.alt ? { alt: this.alt } : {};
     const attrs = {
       class: "quark-image-img",
       style: {

--- a/packages/quark/src/list/index.tsx
+++ b/packages/quark/src/list/index.tsx
@@ -46,7 +46,7 @@ class QuarkList extends QuarkElement {
   textcolor = "#879099";
 
   @property()
-  loadingtext: string = Locale.current.loading;
+  loadingtext = Locale.current.loading;
 
   @property()
   finishedtext = "";

--- a/packages/quark/src/popupextra/index.test.js
+++ b/packages/quark/src/popupextra/index.test.js
@@ -1,16 +1,16 @@
-// import { expect, fixture } from '@open-wc/testing';
-// import sinon from 'sinon';
-// import 'quarkd/lib/popupextra';
+import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
+import 'quarkd/lib/popupextra';
 
-// const data = {
-//   title: "主标题",
-//   subtitle: "副标题",
-//   round: true,
-//   open: true,
-// };
-// let el;
+const data = {
+  title: "主标题",
+  subtitle: "副标题",
+  round: false,
+  open: true,
+};
+let el;
 
-// describe("<quark-popupextra>", async () => {
+describe("<quark-popupextra>", async () => {
 //   it("round attribute", async () => {
 //     el = await fixture(
 //       `<quark-popupextra 
@@ -18,56 +18,56 @@
 //           >
 //           </quark-popupextra>`
 //     );
-//     expect(el.round).to.exist;
+//     expect(el.round).to.equal(false);
 //   });
 
-//   it("open attribute", async () => {
-//     el = await fixture(
-//       `<quark-popupextra 
-//             open=${data.open}
-//           >
-//           </quark-popupextra>`
-//     );
-//     expect(el.open).to.exist;
-//   });
+  it("open attribute", async () => {
+    el = await fixture(
+      `<quark-popupextra 
+            open=${data.open}
+          >
+          </quark-popupextra>`
+    );
+    expect(el.open).to.equal(data.open);
+  });
 
-//   it("title attribute", async () => {
-//     el = await fixture(
-//       `<quark-popupextra 
-//             title=${data.title}
-//           >
-//           </quark-popupextra>`
-//     );
-//     expect(el.closeable).to.exist;
-//   });
+  it("title attribute", async () => {
+    el = await fixture(
+      `<quark-popupextra 
+            title=${data.title}
+          >
+          </quark-popupextra>`
+    );
+    expect(el.title).to.equal(data.title);
+  });
 
-//   it("subtitle attribute", async () => {
-//     el = await fixture(
-//       `<quark-popupextra 
-//             subtitle=${data.subtitle}
-//           >
-//           </quark-popupextra>`
-//     );
-//     expect(el.closeable).to.exist;
-//   });
+  it("subtitle attribute", async () => {
+    el = await fixture(
+      `<quark-popupextra 
+            subtitle=${data.subtitle}
+          >
+          </quark-popupextra>`
+    );
+    expect(el.subtitle).to.equal(data.subtitle);
+  });
 
-//   it("onClose event", async () => {
-//     el = await fixture(
-//       `<quark-popupextra>
-//           </quark-popupextra>`
-//     );
-//     const eventspy = sinon.spy();
-//     el.addEventListener("closed", eventspy);
-//     const maskRef = el.shadowRoot.getElementById("mask");
-//     maskRef.dispatchEvent(new Event("click"));
-//     expect(eventspy.called).to.equal(true);
-//   });
+  it("onClose event", async () => {
+    el = await fixture(
+      `<quark-popupextra>
+          </quark-popupextra>`
+    );
+    const eventspy = sinon.spy();
+    el.addEventListener("closed", eventspy);
+    const maskRef = el.shadowRoot.querySelector(".quark-popup-extra-mask");
+    maskRef.dispatchEvent(new Event("click"));
+    expect(eventspy.called).to.equal(true);
+  });
 
-//   it("slot", async () => {
-//     const slot = `<span>我是正文</span>`;
-//     el = await fixture(`<quark-popupextra>${slot}</quark-popupextra>`);
-//     const descE = el.shadowRoot.querySelector("slot");
-//     const slotResult = descE.assignedNodes()[0];
-//     expect(slotResult.outerHTML).to.equal(slot);
-//   });
-// });
+  it("slot", async () => {
+    const slot = `<div slot="title"> <span>我是正文</span> </div>`;
+    el = await fixture(`<quark-popupextra>${slot}</quark-popupextra>`);
+    const descE = el.shadowRoot.querySelector("slot");
+    const slotResult = descE.assignedNodes()[0];
+    expect(slotResult.outerHTML).to.equal(slot);
+  });
+});


### PR DESCRIPTION
1. fix test (dialog/image/popupextra)
2. oktext = Locale.current.conform -> confirm 不过主分支好像几小时前已经修复了
 给 confirm按钮加上了 class="quark-dialog-confirm-btn" ，方便单测