### PR TITLE
fix: turn off 'no-var-requires' rule to fix error of js files.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,44 +1,41 @@
 {
-    "root": true,
-    "env": {
-        "node": true
-    },
-    "extends": [
-        "plugin:vue/vue3-essential",
-        "eslint:recommended",
-        "@vue/typescript/recommended",
-        "@vue/prettier",
-        "@vue/prettier/@typescript-eslint"
-    ],
-    "parserOptions": {
-        "ecmaVersion": 2020
-    },
-    "rules": {
-        "vue/no-unused-components": 0,
-        "no-debugger": 0,
-        "@typescript-eslint/no-inferrable-types": 1,
+  "root": true,
+  "env": {
+    "node": true
+  },
+  "extends": [
+    "plugin:vue/vue3-essential",
+    "eslint:recommended",
+    "@vue/typescript/recommended",
+    "@vue/prettier",
+    "@vue/prettier/@typescript-eslint"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "rules": {
+    "vue/no-unused-components": 0,
+    "no-debugger": 0,
+    "@typescript-eslint/no-inferrable-types": 1,
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/no-var-requires": 0,
+    "vue/comment-directive": "off"
+  },
+  "overrides": [
+    {
+      "files": ["packages/quark/**/*.tsx"],
+      "rules": {
         "@typescript-eslint/explicit-module-boundary-types": 0,
-        "vue/comment-directive": "off"
+        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/no-empty-function": 0,
+        "@typescript-eslint/no-inferrable-types": 2
+      }
     },
-    "overrides": [
-        {
-            "files":[
-                "packages/quark/**/*.tsx"
-            ],
-            "rules": {
-                "@typescript-eslint/explicit-module-boundary-types": 0,
-                "@typescript-eslint/no-explicit-any": 0,
-                "@typescript-eslint/no-empty-function": 0,
-                "@typescript-eslint/no-inferrable-types": 2
-            }
-        },
-        {
-            "files":[
-                "packages/quark-react/src/**/*.ts"
-            ],
-            "rules": {
-                "@typescript-eslint/no-empty-interface": 0
-            }
-        }
-    ]
+    {
+      "files": ["packages/quark-react/src/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-empty-interface": 0
+      }
+    }
+  ]
 }

--- a/example/src/sites/doc/router.ts
+++ b/example/src/sites/doc/router.ts
@@ -79,7 +79,7 @@ routes.push({
 	name: "notFound",
 	path: "/:path(.*)+",
 	redirect: {
-		name: "index",
+		path: "/zh-CN/component/button",
 	},
 });
 

--- a/packages/quark/typesGenerat.js
+++ b/packages/quark/typesGenerat.js
@@ -1,7 +1,6 @@
-
 const fs = require("fs-extra");
 const path = require("path");
-const sh = require("shelljs")
+const sh = require("shelljs");
 
 const packageSrcRoot = path.join(__dirname, "./src");
 const typesSrcRoot = path.join(__dirname, "./types");


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/53017934/218433946-596df7be-8e69-4014-bd0f-1aa7dbbc0518.png)

https://github.com/typescript-eslint/typescript-eslint/issues/1724

BTW, this commit corrected some wrong indentation.