### PR TITLE
fix: 文档遮挡

### DIFF
--- a/example/src/sites/mobile-vue/App.vue
+++ b/example/src/sites/mobile-vue/App.vue
@@ -104,7 +104,7 @@ export default defineComponent({
 
 	#nav {
 		position: fixed;
-		z-index: 10;
+		z-index: 9999;
 		left: 0;
 		right: 0;
 		height: 57px;


### PR DESCRIPTION
z-index 层级不够导致的遮挡效果应该是不太符合预期的

不确定9999是否符合项目的规范，可以提供规范的数值，我改一下
<img width="388" alt="image" src="https://github.com/hellof2e/quark-design/assets/117748716/94711e02-a444-4b9a-8aad-6466d75b874e">
