### PR TITLE
fix: 修复toast组件函数式调用不能立即关闭的问题

### DIFF
--- a/packages/quarkd/src/toast/index.tsx
+++ b/packages/quarkd/src/toast/index.tsx
@@ -108,7 +108,9 @@ class QuarkToast extends QuarkElement {
   }
 
   hide = () => {
-    this.show = false;
+    setTimeout(() => {
+      this.show = false;
+    });
     if (this.type === "loading") clearAllBodyScrollLocks();
   };
 


### PR DESCRIPTION
### 问题：
通过函数式调用弹出 toast 之后，立马调用 hide 方法或者通过 Promise.resolve().then 调用 hide 方法，toast 不会隐藏。

### 原因：
通过函数调用弹出 toast 时，并不会立即将 toast 的 show 属性设置为 true，而是会在定时器中将 show 属性设置为 true，此时如果立即通过 hide 方法关闭 toast，在下一轮事件循环中，还是会将 show 设置为 true，toast 也不会被关闭。

### 截图：
![截屏2024-01-12 19 16 27](https://github.com/hellof2e/quark-design/assets/58252152/fee372ff-63cb-4a61-a36f-28255b174cc1)

### 解决：
在调用 hide 时，也使用定时器将 show 设置为 false。