### PR TITLE
fix: sites mobile-vue layout

### DIFF
--- a/example/src/sites/mobile-vue/components/Index.vue
+++ b/example/src/sites/mobile-vue/components/Index.vue
@@ -101,7 +101,7 @@ export default defineComponent({
 					display: flex;
 					align-items: center;
 					padding: 0 24px;
-					width: 100%;
+					width: auto;
 					height: 42px;
 					line-height: 42px;
 					background: rgba(255, 255, 255, 1);


### PR DESCRIPTION
https://quark-design.hellobike.com/demo/demo.html#/#/

before
![image](https://github.com/hellof2e/quark-design/assets/37658262/8256399c-319c-44cc-80fe-c26dab849ba8)

after
<img width="472" alt="image" src="https://github.com/hellof2e/quark-design/assets/37658262/80cf42f5-755b-4688-acfb-a9955204c479">
